### PR TITLE
解决体积超700M的bug

### DIFF
--- a/3-init-packages.sh
+++ b/3-init-packages.sh
@@ -79,11 +79,9 @@ EOF
 }
 
 main() {
-	# apt_update
-	# install_package nginx typecho h5ai transmission ttyd frpc aria2 v2ray teslamate \
-	# 	docker samba web2 webdav gitweb nfs-server vsftpd others bootargs
+	apt_update
 	install_all_package
-	# apt_clear
+	apt_clear
 }
 
 main


### PR DESCRIPTION
之前测试的时候把清理 apt 的命令注释掉了，之后忘了把注释去掉，导致体积超出700M